### PR TITLE
Fix for overlaps not being Node instances

### DIFF
--- a/src/core/distributor.js
+++ b/src/core/distributor.js
@@ -140,7 +140,7 @@ var Distributor = function(options){
 
     nodes.forEach(function(node){
       var overlaps = iTree.search(node.idealLeft(), node.idealRight());
-      node.overlaps = overlaps;
+      node.overlaps = overlaps.map(function(x) { return x.data[2]; });
       node.overlapCount = overlaps.length;
     });
 


### PR DESCRIPTION
This commit fixes a bug in the overlap algorithm. The function countIdealOverlaps is used to assign to each Node the nodes with which it overlaps. In the overlap algorithm, as soon as a node is removed the nodes with which it overlaps get a reduced overlapCount in [line 96 of distributor.js](https://github.com/GjjvdBurg/labella.js/blob/dev/src/core/distributor.js#L96). However, countIdealOverlaps does not assign Node instances to the overlaps variable of each node, but Interval result objects (as a result of searching on the interval tree). This commit fixes this behavior, which ensures the overlapCount is properly reduced and thus the overlap algorithm works as (most likely) intended.