### PR TITLE
Use https instead of http in urls

### DIFF
--- a/examples/style.css
+++ b/examples/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Lato:100,300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Lato:100,300,400,700);
 
 body{
   font-family: 'Lato', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.